### PR TITLE
[server][client] Basic analyze screenshot endpoint and hotkey client

### DIFF
--- a/client/src/main.py
+++ b/client/src/main.py
@@ -1,0 +1,36 @@
+import io
+
+import keyboard
+import requests
+from PIL import ImageGrab
+
+
+def capture_and_send() -> None:
+    """Capture screenshot and send to server."""
+    screenshot = ImageGrab.grab()
+    buffer = io.BytesIO()
+    screenshot.save(buffer, format="PNG")
+    buffer.seek(0)
+    files = {"image": ("screenshot.png", buffer, "image/png")}
+    data = {"query": "What should I do next?"}
+    try:
+        response = requests.post(
+            "http://localhost:8000/api/v1/analyze_situation",
+            files=files,
+            data=data,
+            timeout=10,
+        )
+        print(response.json())
+    except requests.RequestException as exc:
+        print(f"Request failed: {exc}")
+
+
+def main() -> None:
+    """Entry point for the client."""
+    keyboard.add_hotkey("ctrl+shift+i", capture_and_send)
+    print("Press Ctrl+Shift+I to analyze situation. Press Esc to quit.")
+    keyboard.wait("esc")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/src/api/endpoints/analyze.py
+++ b/server/src/api/endpoints/analyze.py
@@ -1,0 +1,20 @@
+"""Endpoint for screenshot analysis placeholder."""
+
+from fastapi import APIRouter, File, Form, UploadFile
+
+router = APIRouter()
+
+
+@router.post("/analyze_situation")
+async def analyze_situation(
+    image: UploadFile = File(...), query: str = Form(...)
+) -> dict[str, str | int]:
+    """Receive screenshot and query, return image size."""
+    content = await image.read()
+    size = len(content)
+    return {
+        "image_size_bytes": size,
+        "message": (
+            "Screenshot and query received successfully. LLM processing placeholder."
+        ),
+    }

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -1,0 +1,9 @@
+"""Main entry for FastAPI server."""
+
+from fastapi import FastAPI
+
+from .api.endpoints.analyze import router as analyze_router
+
+app = FastAPI()
+
+app.include_router(analyze_router, prefix="/api/v1")

--- a/tests/unit/test_analyze_situation_endpoint.py
+++ b/tests/unit/test_analyze_situation_endpoint.py
@@ -1,0 +1,17 @@
+from io import BytesIO
+
+from fastapi.testclient import TestClient
+
+from server.src.main import app
+
+
+def test_analyze_situation_endpoint() -> None:
+    client = TestClient(app)
+    image_content = b"fakeimage"
+    files = {"image": ("test.png", BytesIO(image_content), "image/png")}
+    data = {"query": "What should I do next?"}
+    response = client.post("/api/v1/analyze_situation", files=files, data=data)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["image_size_bytes"] == len(image_content)
+    assert "Screenshot and query received" in payload["message"]


### PR DESCRIPTION
## Summary
Adds a minimal client-server interaction for screenshot analysis.

## Changes Made
- Implemented `/api/v1/analyze_situation` FastAPI endpoint returning uploaded image size.
- Added main FastAPI application setup.
- Created hotkey-based client script capturing a screenshot and posting it to the server.
- Added unit test covering the new endpoint.

## Testing
- `python -m isort server/ client/ tests/`
- `python -m flake8 server/ client/ tests/`
- `python -m mypy server/src/`
- `pytest tests/ -v`
